### PR TITLE
Use the modified attribute in the Tower objects to detect updates

### DIFF
--- a/internal/models/base/base.go
+++ b/internal/models/base/base.go
@@ -2,7 +2,9 @@ package base
 
 import (
 	"database/sql"
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -26,14 +28,17 @@ type Base struct {
 type Tower struct {
 	SourceRef       string
 	SourceCreatedAt time.Time
-	// SourceUpdatedAt  time.Time
+	SourceUpdatedAt time.Time
 	// SourceDeletedAt  sql.NullTime
 	LastSeenAt sql.NullTime
 }
 
 //TowerTime converts datetime from Tower to UTC
 func TowerTime(str string) (time.Time, error) {
-	t, err := time.Parse(time.RFC3339, str)
+	//"2020-01-08T10:22:59.423585Z"
+	// Drop the subseconds
+	s := fmt.Sprintf("%sZ", strings.Split(str, ".")[0])
+	t, err := time.Parse(time.RFC3339, s)
 	return t, err
 }
 

--- a/internal/models/servicecredentialtype/servicecredentialtype_test.go
+++ b/internal/models/servicecredentialtype/servicecredentialtype_test.go
@@ -10,16 +10,17 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/RedHatInsights/catalog_tower_persister/internal/models/base"
 	"github.com/RedHatInsights/catalog_tower_persister/internal/models/testhelper"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
 
 var objectType = "credential_type"
-
+var modifiedDateTime = "2020-01-08T10:22:59.423585Z"
 var defaultAttrs = map[string]interface{}{
 	"created":     "2020-01-08T10:22:59.423567Z",
-	"modified":    "2020-01-08T10:22:59.423585Z",
+	"modified":    modifiedDateTime,
 	"id":          json.Number("4"),
 	"name":        "demo",
 	"description": "openshift",
@@ -29,7 +30,7 @@ var defaultAttrs = map[string]interface{}{
 }
 
 var columns = []string{"id", "created_at", "updated_at", "archived_at", "source_ref",
-	"source_created_at", "last_seen_at", "name", "description", "kind",
+	"source_created_at", "source_updated_at", "last_seen_at", "name", "description", "kind",
 	"namespace", "tenant_id", "source_id"}
 var tenantID = int64(99)
 var sourceID = int64(1)
@@ -107,7 +108,7 @@ func TestCreateError(t *testing.T) {
 		WithArgs(srcRef, sourceID).
 		WillReturnError(gorm.ErrRecordNotFound)
 	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "service_credential_types"`)).
-		WithArgs(testhelper.AnyTime{}, testhelper.AnyTime{}, nil, srcRef, sqlmock.AnyArg(), sqlmock.AnyArg(), defaultAttrs["name"], defaultAttrs["description"], defaultAttrs["kind"], defaultAttrs["namespace"], tenantID, sourceID).
+		WithArgs(testhelper.AnyTime{}, testhelper.AnyTime{}, nil, srcRef, testhelper.AnyTime{}, testhelper.AnyTime{}, sqlmock.AnyArg(), defaultAttrs["name"], defaultAttrs["description"], defaultAttrs["kind"], defaultAttrs["namespace"], tenantID, sourceID).
 		WillReturnError(fmt.Errorf("kaboom"))
 
 	sct := ServiceCredentialType{SourceID: sourceID, TenantID: tenantID}
@@ -129,10 +130,10 @@ func TestCreate(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(str)).
 		WithArgs(srcRef, sourceID).
 		WillReturnError(gorm.ErrRecordNotFound)
-	insertStr := `INSERT INTO "service_credential_types" ("created_at","updated_at","archived_at","source_ref","source_created_at","last_seen_at","name","description","kind","namespace","tenant_id","source_id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`
+	insertStr := `INSERT INTO "service_credential_types" ("created_at","updated_at","archived_at","source_ref","source_created_at","source_updated_at","last_seen_at","name","description","kind","namespace","tenant_id","source_id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`
 
 	mock.ExpectQuery(regexp.QuoteMeta(insertStr)).
-		WithArgs(testhelper.AnyTime{}, testhelper.AnyTime{}, nil, srcRef, sqlmock.AnyArg(), sqlmock.AnyArg(), defaultAttrs["name"].(string), defaultAttrs["description"].(string), defaultAttrs["kind"].(string), defaultAttrs["namespace"].(string), tenantID, sourceID).
+		WithArgs(testhelper.AnyTime{}, testhelper.AnyTime{}, nil, srcRef, testhelper.AnyTime{}, testhelper.AnyTime{}, sqlmock.AnyArg(), defaultAttrs["name"].(string), defaultAttrs["description"].(string), defaultAttrs["kind"].(string), defaultAttrs["namespace"].(string), tenantID, sourceID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(newID))
 	err := scr.CreateOrUpdate(ctx, testhelper.TestLogger(), &sct, defaultAttrs)
 	assert.Nil(t, err, "CreateOrUpdate failed")
@@ -155,7 +156,7 @@ func TestCreateOrUpdateError(t *testing.T) {
 	srcRef := "4"
 	id := int64(1)
 	rows := sqlmock.NewRows(columns).
-		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
+		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
 	ctx := context.TODO()
 	scr := NewGORMRepository(gdb)
 	sct := ServiceCredentialType{SourceID: sourceID, TenantID: tenantID}
@@ -176,7 +177,7 @@ func TestCreateOrUpdate(t *testing.T) {
 	id := int64(1)
 	srcRef := "4"
 	rows := sqlmock.NewRows(columns).
-		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
+		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
 	ctx := context.TODO()
 	scr := NewGORMRepository(gdb)
 	sct := ServiceCredentialType{SourceID: sourceID, TenantID: tenantID}
@@ -196,6 +197,31 @@ func TestCreateOrUpdate(t *testing.T) {
 
 }
 
+func TestNoChange(t *testing.T) {
+	gdb, mock, teardown := testhelper.MockDBSetup(t)
+	defer teardown()
+	id := int64(1)
+	srcRef := "4"
+	mt, _ := base.TowerTime(modifiedDateTime)
+	rows := sqlmock.NewRows(columns).
+		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), mt, time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
+	ctx := context.TODO()
+	scr := NewGORMRepository(gdb)
+	sct := ServiceCredentialType{SourceID: sourceID, TenantID: tenantID}
+	str := `SELECT * FROM "service_credential_types" WHERE "service_credential_types"."source_ref" = $1 AND "service_credential_types"."source_id" = $2 AND "service_credential_types"."archived_at" IS NULL ORDER BY "service_credential_types"."id" LIMIT 1`
+	mock.ExpectQuery(regexp.QuoteMeta(str)).
+		WithArgs(srcRef, sourceID).
+		WillReturnRows(rows)
+	err := scr.CreateOrUpdate(ctx, testhelper.TestLogger(), &sct, defaultAttrs)
+
+	assert.Nil(t, err, "CreateOrUpdate failed")
+	assert.NoError(t, mock.ExpectationsWereMet(), "There were unfulfilled expectations")
+	stats := scr.Stats()
+	assert.Equal(t, stats["adds"], 0)
+	assert.Equal(t, stats["updates"], 0)
+	assert.Equal(t, stats["deletes"], 0)
+}
+
 func TestDeleteUnwantedMissing(t *testing.T) {
 	gdb, mock, teardown := testhelper.MockDBSetup(t)
 	defer teardown()
@@ -203,7 +229,7 @@ func TestDeleteUnwantedMissing(t *testing.T) {
 	srcRef := "2"
 
 	rows := sqlmock.NewRows(columns).
-		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
+		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
 
 	ctx := context.TODO()
 	scr := NewGORMRepository(gdb)
@@ -230,7 +256,7 @@ func TestDeleteUnwanted(t *testing.T) {
 	srcRef := "2"
 
 	rows := sqlmock.NewRows(columns).
-		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
+		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
 
 	ctx := context.TODO()
 	scr := NewGORMRepository(gdb)
@@ -281,7 +307,7 @@ func TestDeleteUnwantedErrorInDelete(t *testing.T) {
 	srcRef := "2"
 
 	rows := sqlmock.NewRows(columns).
-		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
+		AddRow(id, time.Now(), time.Now(), nil, srcRef, time.Now(), time.Now(), time.Now(), "test_name", "test_desc", "test_kind", "test_ns", tenantID, sourceID)
 
 	ctx := context.TODO()
 	scr := NewGORMRepository(gdb)

--- a/internal/models/serviceplan/serviceplan.go
+++ b/internal/models/serviceplan/serviceplan.go
@@ -1,6 +1,7 @@
 package serviceplan
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -81,17 +82,19 @@ func (gr *gormRepository) CreateOrUpdate(ctx context.Context, logger *logrus.Ent
 	} else {
 		logger.Infof("Survey Spec %s exists in DB with ID %d", sp.SourceRef, instance.ID)
 		sp.ID = instance.ID // Get the Existing ID for the object
-		instance.CreateJSONSchema = sp.CreateJSONSchema
-		instance.Description = sp.Description
-		instance.Name = sp.Name
+		if bytes.Compare(instance.CreateJSONSchema, sp.CreateJSONSchema) != 0 {
+			instance.CreateJSONSchema = sp.CreateJSONSchema
+			instance.Description = sp.Description
+			instance.Name = sp.Name
 
-		logger.Infof("Saving Survey Spec  source_ref %s", sp.SourceRef)
-		err := gr.db.Save(&instance).Error
-		if err != nil {
-			logger.Errorf("Error Updating Service Plan  source_ref %s", sp.SourceRef)
-			return err
+			logger.Infof("Saving Survey Spec  source_ref %s", sp.SourceRef)
+			err := gr.db.Save(&instance).Error
+			if err != nil {
+				logger.Errorf("Error Updating Service Plan  source_ref %s", sp.SourceRef)
+				return err
+			}
+			gr.updates++
 		}
-		gr.updates++
 	}
 	return nil
 }


### PR DESCRIPTION
Previously we were using the modified__gt to detect updates coming
from the tower which fails when an old job template is shared with
the user. For the survey we compare the bytes since they don't have
the modified attribute