### PR TITLE
Log Panic errors

### DIFF
--- a/catalog_tower_persister.go
+++ b/catalog_tower_persister.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -29,6 +30,12 @@ func main() {
 	log := logger.InitLogger()
 	log.Info("Starting Catalog Tower Persister")
 	defer log.Info("Finished Catalog Worker")
+	defer func() {
+		if err := recover(); err != nil {
+			log.Error("panic occurred:", err)
+			log.Error("Stack Trace ", string(debug.Stack()))
+		}
+	}()
 
 	isReady := &atomic.Value{}
 	isReady.Store(false)

--- a/persister_worker.go
+++ b/persister_worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -32,6 +33,14 @@ func startPersisterWorker(ctx context.Context, db DatabaseContext, logger *logru
 	defer logger.Info("Persister Worker finished")
 	defer wg.Done()
 	logger.Info("Persister Worker started")
+
+	defer func() {
+		if err := recover(); err != nil {
+
+			logger.Errorf("Stack Trace %s", string(debug.Stack()))
+			logger.Errorf("Panic occured %v", err)
+		}
+	}()
 	duration := 15 * time.Minute
 	newCtx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()


### PR DESCRIPTION
If for some reason the persister panics and dies it wasn't logging
any errors. With this PR we should be able to log panic errors and
the corresponding stack trace
https://issues.redhat.com/browse/SSP-2461