### PR TITLE
Fix pr check failure due to wrong component name

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -59,7 +59,7 @@ objects:
     database:
       sharedDbAppName: catalog-inventory
     dependencies:
-    - catalog-inventory
+    - catalog_inventory-api
 
 parameters:
 - name: LOG_LEVEL

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,7 +4,7 @@
 # Options that must be configured by app owner
 # --------------------------------------------
 APP_NAME="catalog-tower-persister"  # name of app-sre "application" folder this component lives in
-COMPONENT_NAME="catalog-tower-persister"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+COMPONENT_NAME="catalog_tower_persister"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/catalog_tower_persister"  
 
 IQE_PLUGINS="catalog-tower-persister"


### PR DESCRIPTION
Change `COMPONENT_NAME` to match with deployment script.